### PR TITLE
Add missing seconds attr to Fugit::Cron

### DIFF
--- a/lib/fugit/cron.rb
+++ b/lib/fugit/cron.rb
@@ -15,7 +15,7 @@ module Fugit
     }
 
     attr_reader :original, :zone
-    attr_reader :minutes, :hours, :monthdays, :months, :weekdays, :timezone
+    attr_reader :seconds, :minutes, :hours, :monthdays, :months, :weekdays, :timezone
 
     class << self
 


### PR DESCRIPTION
The `Fugit::Cron` class has attr readers for the `minutes`, `hours` etc. fields, but it does not have an attr reader for the `seconds` field in the alternative cron syntax:

```
irb(main):003:0> Fugit::Cron.parse('30 * * * * *').seconds
=> [30]
```