### PR TITLE
Avoid 2.5 warnings

### DIFF
--- a/lib/fugit/cron.rb
+++ b/lib/fugit/cron.rb
@@ -28,7 +28,6 @@ module Fugit
 
         return s if s.is_a?(self)
 
-        original = s
         s = SPECIALS[s] || s
 
         return nil unless s.is_a?(String)
@@ -94,7 +93,7 @@ module Fugit
       def inc_min; inc(60 - @t.sec); end
 
       def inc_sec(seconds)
-        if s = seconds.find { |s| s > @t.sec }
+        if s = seconds.find { |local_s| local_s > @t.sec }
           inc(s - @t.sec)
         else
           inc(60 - @t.sec + seconds.first)
@@ -123,7 +122,7 @@ module Fugit
 
       return true if @weekdays.nil?
 
-      wd, hsh = @weekdays.find { |wd, hsh| wd == nt.wday }
+      wd, hsh = @weekdays.find { |local_wd, _hsh| local_wd == nt.wday }
 
       return false unless wd
       return true if hsh.nil?
@@ -329,28 +328,28 @@ module Fugit
     end
 
     def determine_seconds(a)
-      @seconds = (a || [ 0 ]).inject([]) { |a, r| a.concat(expand(0, 59, r)) }
+      @seconds = (a || [ 0 ]).inject([]) { |local_a, r| local_a.concat(expand(0, 59, r)) }
       compact(:@seconds)
     end
 
     def determine_minutes(a)
-      @minutes = a.inject([]) { |a, r| a.concat(expand(0, 59, r)) }
+      @minutes = a.inject([]) { |local_a, r| local_a.concat(expand(0, 59, r)) }
       compact(:@minutes)
     end
 
     def determine_hours(a)
-      @hours = a.inject([]) { |a, r| a.concat(expand(0, 23, r)) }
+      @hours = a.inject([]) { |local_a, r| local_a.concat(expand(0, 23, r)) }
       @hours = @hours.collect { |h| h == 24 ? 0 : h }
       compact(:@hours)
     end
 
     def determine_monthdays(a)
-      @monthdays = a.inject([]) { |a, r| a.concat(expand(1, 31, r)) }
+      @monthdays = a.inject([]) { |local_a, r| local_a.concat(expand(1, 31, r)) }
       compact(:@monthdays)
     end
 
     def determine_months(a)
-      @months = a.inject([]) { |a, r| a.concat(expand(1, 12, r)) }
+      @months = a.inject([]) { |local_a, r| local_a.concat(expand(1, 12, r)) }
       compact(:@months)
     end
 
@@ -358,16 +357,16 @@ module Fugit
 
       @weekdays = []
 
-      a.each do |a, z, s, h| # a to z, slash and hash
+      a.each do |local_a, z, s, h| # a to z, slash and hash
         if h
-          @weekdays << [ a, h ]
+          @weekdays << [ local_a, h ]
         elsif s
-          ((a || 0)..(z || (a ? a : 6))).step(s < 1 ? 1 : s)
+          ((local_a || 0)..(z || (local_a ? local_a : 6))).step(s < 1 ? 1 : s)
             .each { |i| @weekdays << [ i ] }
         elsif z
-          (a..z).each { |i| @weekdays << [ i ] }
-        elsif a
-          @weekdays << [ a ]
+          (local_a..z).each { |i| @weekdays << [ i ] }
+        elsif local_a
+          @weekdays << [ local_a ]
         #else
         end
       end

--- a/lib/fugit/duration.rb
+++ b/lib/fugit/duration.rb
@@ -129,14 +129,14 @@ module Fugit
     def inflate
 
       h =
-        @h.inject({ sec: 0 }) { |h, (k, v)|
+        @h.inject({ sec: 0 }) { |local_h, (k, v)|
           a = KEYS[k]
           if a[:I]
-            h[:sec] += (v * a[:s])
+            local_h[:sec] += (v * a[:s])
           else
-            h[k] = v
+            local_h[k] = v
           end
-          h
+          local_h
         }
 
       self.class.allocate.init(@original, {}, h)
@@ -184,7 +184,7 @@ module Fugit
 
     def opposite
 
-      h = @h.inject({}) { |h, (k, v)| h[k] = -v; h }
+      h = @h.inject({}) { |local_h, (k, v)| local_h[k] = -v; local_h }
 
       self.class.allocate.init(nil, {}, h)
     end
@@ -201,7 +201,7 @@ module Fugit
 
     def add_duration(d)
 
-      h = d.h.inject(@h.dup) { |h, (k, v)| h[k] = (h[k] || 0) + v; h }
+      h = d.h.inject(@h.dup) { |local_h, (k, v)| local_h[k] = (local_h[k] || 0) + v; local_h }
 
       self.class.allocate.init(nil, {}, h)
     end
@@ -312,10 +312,10 @@ module Fugit
 
       t
         .subgather(nil)
-        .inject({}) { |h, t|
-          v = t.string; v = v.index('.') ? v.to_f : v.to_i
+        .inject({}) { |h, local_t|
+          v = local_t.string; v = v.index('.') ? v.to_f : v.to_i
             # drops ending ("y", "m", ...) by itself
-          h[t.name] = (h[t.name] || 0) + v
+          h[local_t.name] = (h[local_t.name] || 0) + v
           h
         }
     end

--- a/lib/fugit/nat.rb
+++ b/lib/fugit/nat.rb
@@ -49,7 +49,7 @@ module Fugit
         end
       end
       h[:min] ||= [ 0 ]
-      h[:dow].sort_by! { |a, z| a || 0 }
+      h[:dow].sort_by! { |local_a, z| local_a || 0 }
 
       Fugit::Cron.allocate.send(:init, nil, h)
     end


### PR DESCRIPTION
```
$ ruby -cw lib/fugit/cron.rb
lib/fugit/cron.rb:31: warning: assigned but unused variable - original
lib/fugit/cron.rb:97: warning: shadowing outer local variable - s
lib/fugit/cron.rb:126: warning: shadowing outer local variable - wd
lib/fugit/cron.rb:126: warning: shadowing outer local variable - hsh
lib/fugit/cron.rb:332: warning: shadowing outer local variable - a
lib/fugit/cron.rb:337: warning: shadowing outer local variable - a
lib/fugit/cron.rb:342: warning: shadowing outer local variable - a
lib/fugit/cron.rb:348: warning: shadowing outer local variable - a
lib/fugit/cron.rb:353: warning: shadowing outer local variable - a
lib/fugit/cron.rb:361: warning: shadowing outer local variable - a
Syntax OK

$ ruby -cw lib/fugit/cron.rb
lib/fugit/duration.rb:132: warning: shadowing outer local variable - h
lib/fugit/duration.rb:187: warning: shadowing outer local variable - h
lib/fugit/duration.rb:204: warning: shadowing outer local variable - h
lib/fugit/duration.rb:315: warning: shadowing outer local variable - t
Syntax OK

$ ruby -cw lib/fugit/nat.rb
lib/fugit/nat.rb:52: warning: shadowing outer local variable - a
Syntax OK
```

Some of these appear in [Rails CI](https://travis-ci.org/rails/rails/jobs/394107740#L3764-L3778)