### PR TITLE
Eliminate "mismatched indentations" warning by aligning case - when - else properly

### DIFF
--- a/lib/fugit/nat.rb
+++ b/lib/fugit/nat.rb
@@ -407,7 +407,7 @@ module Fugit
         #when 'm' then slot(:m, pts)
         when 'm' then slot(:hm, '*', pts, strong: 1)
         when 's' then slot(:second, pts)
-else slot(pt.to_sym, pts)
+        else slot(pt.to_sym, pts)
         end
       end
 


### PR DESCRIPTION
Requiring fugit gem causes a Ruby warning "mismatched indentations" in nat.rb
```
$ ruby -rfugit -we 'p Fugit::VERSION'
.../gems/fugit-1.4.0/lib/fugit/nat.rb:410: warning: mismatched indentations at 'else' with 'case' at 406
"1.4.0"
```

From 6ce09d0651a2ec8be80cfde7798297b51e966cfe I can guess that this line was intentionally written this way for debugging purpose, but IMO the released gem might better be warning-free.