### PR TITLE
CI: Add Ruby 3.0 to matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        #ruby: [ jruby ]
-        ruby: [ '2.3', '2.5', '2.6', '2.7', jruby-9.2 ]
+        ruby: [ '2.3', '2.5', '2.6', '2.7', '3.0', jruby-9.2 ]
         experimental: [ false ]
       fail-fast: false
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
This PR only updates the CI matrix with the latest generally available Ruby version.