### PR TITLE
Add Ruby 3.1 and JRuby 9.3 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         #ruby: [ '2.3', '2.5', '2.6', '2.7', '3.0', jruby-9.2 ]
-        ruby: [ 2.3, 2.5, 2.6, 2.7, 3.0, jruby-9.2, truffleruby-21.2 ]
+        ruby: [ 2.3, 2.5, 2.6, 2.7, '3.0', 3.1, jruby-9.2, jruby-9.3, truffleruby-21.2 ]
         experimental: [ false ]
       fail-fast: false
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Add Ruby 3.1 and jruby-9.3 to the CI matrix.

In addition to adding 3.1 and jruby-9.3, we quote '3.0' to ensure that it is not truncated to 3.  An unquoted 3.0 will be truncated to 3, and will load the latest Ruby 3 - which at time of writing is 3.1.0.  To ensure a Ruby 3.0.x is loaded we need to quote it.
