### PR TITLE
easier way to subtract a duration from a time

### DIFF
--- a/lib/fugit/duration.rb
+++ b/lib/fugit/duration.rb
@@ -269,7 +269,7 @@ module Fugit
       when Numeric then add_numeric(-a)
       when Fugit::Duration then add_duration(-a)
       when String then add_duration(-self.class.parse(a))
-      when ::Time, ::EtOrbi::EoTime then add_to_time(a)
+      when ::Time, ::EtOrbi::EoTime then opposite.add_to_time(a)
       else fail ArgumentError.new(
         "cannot subtract #{a.class} instance to a Fugit::Duration")
       end

--- a/spec/duration_spec.rb
+++ b/spec/duration_spec.rb
@@ -468,6 +468,15 @@ describe Fugit::Duration do
       expect((d - s).to_plain_s).to eq('3h1s')
     end
 
+    it 'subtracts Time instances' do
+
+      d = Fugit.parse('1Y2h')
+      t = Time.parse('2016-02-02T11:11:11Z')
+
+      expect(Fugit.time_to_plain_s(d.subtract(t), false)).to eq('2015-02-02 09:11:11')
+      expect(Fugit.time_to_plain_s(d - t, false)).to eq('2015-02-02 09:11:11')
+    end
+
     it 'fails else' do
 
       d = Fugit.parse('1Y2h')


### PR DESCRIPTION
previous behaviour resulted in same as addition:

```ruby
Fugit.parse('1Y') + Time.parse("2023-01-19T12:07:00T")
# => 2024-01-19T12:07:00T

Fugit.parse('1Y') - Time.parse("2023-01-19T12:07:00T")
# => 2024-01-19T12:07:00T
```

With this change, the duration is now subtracted from the time:

```ruby
Fugit.parse('1Y') + Time.parse("2023-01-19T12:07:00T")
# => 2024-01-19T12:07:00T

Fugit.parse('1Y') - Time.parse("2023-01-19T12:07:00T")
# => 2022-01-19T12:07:00T
```

Mathematically this isn't quite correct I suppose, but neither is the current behaviour.