### PR TITLE
Parse Nat support for 1st and last of the month

### DIFF
--- a/lib/fugit/nat.rb
+++ b/lib/fugit/nat.rb
@@ -691,8 +691,10 @@ module Fugit
         a << tz.data0 if tz
         a.shift if a.first == [ '0' ]
 
+        letters_first = ->(x) { x.is_a?(Numeric) ? x : 0 }
+
         s = a
-          .collect { |e| e.uniq.sort.collect(&:to_s).join(',') }
+          .collect { |e| e.uniq.sort_by(&letters_first).collect(&:to_s).join(',') }
           .join(' ')
 
         c = Fugit::Cron.parse(s)

--- a/spec/nat_spec.rb
+++ b/spec/nat_spec.rb
@@ -67,6 +67,8 @@ describe Fugit::Nat do
         'every month on the 1st and 2nd at 12:00 pm' => '0 12 1,2 * *',
         'every month on the 1st and the 2nd at 12:00 pm' => '0 12 1,2 * *',
         'every month on the 1st and the second at 12:00 pm' => '0 12 1,2 * *',
+        'every month on the 1st and last at 12:00 pm' => '0 12 L,1 * *',
+        'every month on the 1st and the last at 12:00 pm' => '0 12 L,1 * *',
           #
           # gh-57, 12pm --> noon
 


### PR DESCRIPTION
@floraison We need to support this pattern in our project: `every month on the 1st and last`.
It seems it should work but when executing the sort here:
```ruby
         .collect { |e| e.uniq.sort.collect(&:to_s).join(',') }
```
It was throwing:
``sort': comparison of String with 1 failed (ArgumentError)`

It was doing something like this:
```ruby
["L", 1].sort
(irb):1:in `sort': comparison of String with 1 failed (ArgumentError)
```

This PR substitutes `sort` with `sort_by` to conditionally handle non numeric values.
