### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/fugit.gemspec
+++ b/fugit.gemspec
@@ -26,6 +26,7 @@ Time tools for flor and the floraison project. Cron parsing and occurrence compu
     'homepage_uri' =>  s.homepage,
     'source_code_uri' => s.homepage,
     #'wiki_uri' => s.homepage + '/wiki',
+    'rubygems_mfa_required' => 'true',
   }
 
   #s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
As a pupular gem, `fugit` implicitly requires that all privileged operations by any of the owners require OTP.

However, by explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and
"VERSION PUBLISHED WITH MFA" in the sidebar at
https://github.com/floraison/fugit

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/

---

![image](https://github.com/user-attachments/assets/edb75f71-2151-4dd7-81f7-97f73c438df3)
