### PR TITLE
Prevent new America timezones being interpreted as AM morning specifiers

### DIFF
--- a/lib/fugit/nat.rb
+++ b/lib/fugit/nat.rb
@@ -210,7 +210,7 @@ module Fugit
       end
 
       def ampm(i)
-        rex(:ampm, i, /[ \t]*(am|pm|noon|midday|midnight)/i)
+        rex(:ampm, i, /[ \t]*(am|AM|pm|PM|[Nn]oon|[Mm]idday|[Mm]idnight)/)
       end
       def dark(i)
         rex(:dark, i, /[ \t]*dark/i)


### PR DESCRIPTION
When I upgraded my container base from `ruby:3.4.4-slim` to `ruby:3.4.5-slim`, the parsing of `every day at midnight US/Pacific` stopped working. I think this is because, unless the `tzdata-legacy` package is installed,   timezones like `US/Pacific` have been replaced with zones like `America/Los_Angeles`.

But Fugit also failed to parse  `America/Los_Angeles`. Indeed, all timezones that start with `America`. This is because the first two characters of `America` is interpreted as a morning specifier.

This PR provides one solution. It [replaces](/floraison/fugit/blob/228b53ded4be3d86412b6dd62c831a7a459d9ef4/lib/fugit/nat.rb#L212)
```
def ampm(i)
  rex(:ampm, i, /[ \t]*(am|pm|noon|midday|midnight)/i)
end 
```
with
```
def ampm(i)
  rex(:ampm, i, /[ \t]*(am|AM|pm|PM|[Nn]oon|[Mm]idday|[Mm]idnight)/)
end 
```