### PR TITLE
Test against latest stable Rubies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,9 @@ jobs:
         os: [
           ubuntu-latest ]
         ruby: [
-          '2.7', '3.0', '3.1', '3.1.6', '3.2', '3.3', '3.4',
-          'jruby-9.4',
-          'truffleruby-24' ]
+          '2.7', '3.0', '3.1', '3.1.6', '3.2', '3.3', '3.4', '4.0',
+          'jruby',
+          'truffleruby']
         experimental: [ false ]
       fail-fast: false
     runs-on: ${{matrix.os}}

--- a/fugit.gemspec
+++ b/fugit.gemspec
@@ -45,6 +45,7 @@ Time tools for flor and the floraison project. Cron parsing and occurrence compu
 
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'chronic', '~> 0.10'
+  s.add_development_dependency 'ostruct'
 
   s.require_path = 'lib'
 end


### PR DESCRIPTION
Add MRI 4.0 to the matrix and remove version number from `jruby-9.4` and `truffleruby-24` so they can point to their latest stable release.

Additionally, add `ostruct` to development dependencies since it is not a default gem starting from Ruby 4.0