### PR TITLE
Support natural language offsets

### DIFF
--- a/lib/fugit/nat.rb
+++ b/lib/fugit/nat.rb
@@ -278,10 +278,27 @@ module Fugit
         rex(:interval, i, INTERVAL_REX)
       end
 
+      def _starting_at(i)
+        rex(nil, i, /[ \t]*(starting[ \t]+at|from)[ \t]+/i)
+      end
+      def _offset_unit(i)
+        rex(nil, i, /(second|minute|hour|day|month)s?[ \t]+/i)
+      end
+      def offset_count(i)
+        rex(:offset_count, i, /\d+/)
+      end
+
+        # starting at minute 1
+        # from minute 1
+      def offset(i)
+        seq(:offset, i, :_starting_at, :_offset_unit, :offset_count)
+      end
+
         # every day
         # every 1 minute
+        # every minute starting at minute 10
       def every_interval(i)
-        seq(:every_interval, i, :count, '?', :interval)
+        seq(:every_interval, i, :count, '?', :interval, :offset, '?')
       end
 
       def every_single_interval(i)
@@ -438,11 +455,19 @@ module Fugit
       def rewrite_every_interval(t)
 
 #Raabro.pp(t, colours: true)
-        ci = t.subgather(nil).collect(&:string)
-        i = ci.pop.strip[0, 3]
-        c = (ci.pop || '1').strip
+        ct = t.sublookup(:count)
+        it = t.sublookup(:interval)
+        ot = t.sublookup(:offset)
+
+        c = (ct ? ct.string : '1').strip
+        i = it.string.strip[0, 3]
         i = (i == 'M' || i.downcase == 'mon') ? 'M' : i[0, 1].downcase
-        cc = c == '1' ? '*' : "*/#{c}"
+        off = ot ? ot.sublookup(:offset_count).string.to_i : nil
+        cc =
+          if off then "#{off}/#{c}"
+          elsif c == '1' then '*'
+          else "*/#{c}"
+          end
 
         case i
         when 'M' then slot(:month, cc)

--- a/spec/nat_spec.rb
+++ b/spec/nat_spec.rb
@@ -186,6 +186,13 @@ describe Fugit::Nat do
           #
           # gh-45
 
+        'every second starting at second 10' => '10/1 * * * * *',
+        'every second from second 10' => '10/1 * * * * *',
+        'every 15 minutes starting at minute 1' => '1/15 * * * *',
+        'every hour starting at hour 8' => '0 8/1 * * *',
+        'every 5 days starting at day 3' => '0 0 3/5 * *',
+        'every month starting at month 6' => '0 0 1 6/1 *',
+
         'every weekday 8am to 5pm' => '0 8-17 * * 1-5',
         'every weekday 8am to 5pm on the hour' => '0 8-17 * * 1-5',
         'every weekday 8am to 5pm on the minute' => '* 8-16 * * 1-5',


### PR DESCRIPTION
At work we have a cron job that runs every 15 minutes (minutes 0, 15, 30, 45). The corresponding natural language expression is easy to write: `every 15 minutes`.
But we also have a second job that runs 1 minute after the first job (minutes 1, 16, 31, 46). There is currently no nice way to express this in natural language besides listing all the minutes: `at minutes 1,16,31,46`.

I thought it might be nice if the natural language parser could support offsets, so the second job's schedule could be rewritten to `every 15 minutes starting at minute 1` or `every 15 minutes from minute 1`.

This PR is an attempt to support such offsets. If this looks useful, I am happy to tweak this further. For example I sort of like the expressiveness of "starting at", but it might look too wordy.